### PR TITLE
Use single PooledMutableBlockPos

### DIFF
--- a/src/main/java/gliby/minecraft/physics/common/entity/mechanics/EnvironmentResponseMechanic.java
+++ b/src/main/java/gliby/minecraft/physics/common/entity/mechanics/EnvironmentResponseMechanic.java
@@ -65,19 +65,21 @@ public class EnvironmentResponseMechanic extends RigidBodyMechanic {
         int minY = MathHelper.floor(bb.minY);
         int minZ = MathHelper.floor(bb.minZ);
 
-        for (int x = minX; x <= maxX; ++x) {
-            for (int y = minY; y <= maxY; ++y) {
-                for (int z = minZ; z <= maxZ; ++z) {
-                    BlockPos.PooledMutableBlockPos blockPosition = BlockPos.PooledMutableBlockPos.retain(x, y, z);
-                    IBlockState blockState = world.getBlockState(blockPosition);
-
-                    if (blockState.getBlock().getMaterial(blockState).isLiquid()) {
-                        blockImportations.add(new BlockStateAndLocation(blockState, blockPosition));
-                    }
-                    blockPosition.release();
-                }
-            }
-        }
+        BlockPos.PooledMutableBlockPos blockPosition = BlockPos.PooledMutableBlockPos.retain();
+		try {
+			for (int x = minX; x <= maxX; ++x) {
+				for (int y = minY; y <= maxY; ++y) {
+					for (int z = minZ; z <= maxZ; ++z) {
+						blockPosition.setPos(x, y, z);
+						IBlockState blockState = world.getBlockState(blockPosition);
+						if (blockState.getBlock().getMaterial(blockState).isLiquid())
+							blockImportations.add(new BlockStateAndLocation(blockState, blockPosition));
+					}
+				}
+			}
+		} finally {
+			blockPosition.release();
+		}
         return blockImportations;
     }
 }

--- a/src/main/java/gliby/minecraft/physics/common/entity/mechanics/RigidBodyMechanic.java
+++ b/src/main/java/gliby/minecraft/physics/common/entity/mechanics/RigidBodyMechanic.java
@@ -48,17 +48,21 @@ public abstract class RigidBodyMechanic {
         int i1 = MathHelper.floor(BB.minZ);
         int j1 = MathHelper.floor(BB.maxZ);
 
-        for (int k1 = i; k1 <= j; ++k1) {
-            for (int l1 = k; l1 <= l; ++l1) {
-                for (int i2 = i1; i2 <= j1; ++i2) {
-                    BlockPos.PooledMutableBlockPos pos = BlockPos.PooledMutableBlockPos.retain(k1, l1, i2);
-                    IBlockState state = world.getBlockState(pos);
-                    if (!state.getBlock().isAir(state, world, pos))
-                        bb.add(new BlockStateAndLocation(state, pos));
-                    pos.release();
-                }
-            }
-        }
+        BlockPos.PooledMutableBlockPos pos = BlockPos.PooledMutableBlockPos.retain();
+		try {
+			for (int k1 = i; k1 <= j; ++k1) {
+				for (int l1 = k; l1 <= l; ++l1) {
+					for (int i2 = i1; i2 <= j1; ++i2) {
+						pos.setPos(k1, l1, i2);
+						IBlockState state = world.getBlockState(pos);
+						if (!state.getBlock().isAir(state, world, pos))
+							bb.add(new BlockStateAndLocation(state, pos));
+					}
+				}
+			}
+		} finally {
+			pos.release();
+		}
         return bb;
     }
 


### PR DESCRIPTION
Using a single PooledMutableBlockPos per loop instead of retaining and releasing one each time is faster as it skips the cost of retrieving and returning the BlockPos from the pool each time. This operations have a high synchronisation cost.